### PR TITLE
Add flags bound to a variable

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
     name: Linter
     runs-on: ubuntu-latest
     steps:

--- a/examples/hello_world/main.go
+++ b/examples/hello_world/main.go
@@ -16,7 +16,7 @@ var hello = commander.Builder(
 		Namespace: "hello",
 		Execute:   runHelloAction,
 	},
-	commander.NoCols,
+	commander.NoCols(),
 )
 
 func init() {
@@ -34,7 +34,7 @@ func init() {
 			Namespace: "es",
 			Execute:   runHolaAction,
 		},
-		commander.NoCols,
+		commander.NoCols(),
 	)
 	hello.AddCommand(es)
 }

--- a/pkg/commander/command.go
+++ b/pkg/commander/command.go
@@ -131,34 +131,38 @@ func Builder(parent *Command, config Config, cols []string) *Command {
 	}
 
 	if cols := c.cols; len(cols) > 0 {
-		formatHelpText := fmt.Sprintf(
-			"select displayable fields to filter the console output, possible values are %s",
-			strings.Join(cols, ","),
-		)
-
-		AddFlag(
-			c,
-			FlagConfig{
-				Name:       "fields",
-				Persistent: true,
-				Shorthand:  "f",
-				Usage:      formatHelpText,
-			},
-		)
-
-		AddFlag(
-			c,
-			FlagConfig{
-				Name:       "no-headers",
-				FlagType:   BoolFlag,
-				Persistent: true,
-				Usage:      "Return raw data with no headers",
-				Default:    false,
-			},
-		)
+		addDisplayerFlags(c)
 	}
 
 	return c
+}
+
+func addDisplayerFlags(c *Command) {
+	formatHelpText := fmt.Sprintf(
+		"select displayable fields to filter the console output, possible values are %s",
+		strings.Join(c.cols, ","),
+	)
+
+	AddFlag(
+		c,
+		FlagConfig{
+			Name:       "fields",
+			Persistent: true,
+			Shorthand:  "f",
+			Usage:      formatHelpText,
+		},
+	)
+
+	AddFlag(
+		c,
+		FlagConfig{
+			Name:       "no-headers",
+			FlagType:   BoolFlag,
+			Persistent: true,
+			Usage:      "Return raw data with no headers",
+			Default:    false,
+		},
+	)
 }
 
 // AddFlag attaches a flag of the given type with the
@@ -210,6 +214,7 @@ func FilterColumns(req string, def []string) []string {
 
 func addIntFlag(flagger *pflag.FlagSet, config *FlagConfig) {
 	val := config.Default.(int)
+
 	if config.Binding.Bound {
 		flagger.IntVarP(config.Binding.BindInt, config.Name, config.Shorthand, val, config.Usage)
 	} else {
@@ -219,6 +224,7 @@ func addIntFlag(flagger *pflag.FlagSet, config *FlagConfig) {
 
 func addInt64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
 	val := config.Default.(int64)
+
 	if config.Binding.Bound {
 		flagger.Int64VarP(config.Binding.BindInt64, config.Name, config.Shorthand, val, config.Usage)
 	} else {
@@ -228,6 +234,7 @@ func addInt64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
 
 func addFloat64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
 	val := config.Default.(float64)
+
 	if config.Binding.Bound {
 		flagger.Float64VarP(config.Binding.BindFloat64, config.Name, config.Shorthand, val, config.Usage)
 	} else {
@@ -237,6 +244,7 @@ func addFloat64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
 
 func addBoolFlag(flagger *pflag.FlagSet, config *FlagConfig) {
 	val := config.Default.(bool)
+
 	if config.Binding.Bound {
 		flagger.BoolVarP(config.Binding.BindBool, config.Name, config.Shorthand, val, config.Usage)
 	} else {
@@ -250,6 +258,7 @@ func addStringFlag(flagger *pflag.FlagSet, config *FlagConfig) {
 	}
 
 	val := config.Default.(string)
+
 	if config.Binding.Bound {
 		flagger.StringVarP(config.Binding.BindString, config.Name, config.Shorthand, val, config.Usage)
 	} else {

--- a/pkg/commander/command.go
+++ b/pkg/commander/command.go
@@ -14,16 +14,30 @@ var NoCols = []string{}
 
 // Config contains a command configuration.
 type Config struct {
-	Aliases   []string
-	Example   string
-	Execute   func(cmd *cobra.Command, args []string)
-	Hidden    bool
-	LongDesc  string
-	Namespace string
-	PostHook  func(cmd *cobra.Command, args []string)
-	PreHook   func(cmd *cobra.Command, args []string)
-	ShortDesc string
-	ValidArgs []string
+	Aliases               []string
+	Deprecated            string
+	DisableAutoGenTag     bool
+	DisableSuggentions    bool
+	SuggestMinDistance    int
+	Example               string
+	Execute               func(cmd *cobra.Command, args []string)
+	ExecuteErr            func(cmd *cobra.Command, args []string) error
+	Hidden                bool
+	LongDesc              string
+	Namespace             string
+	PersistentPostHook    func(cmd *cobra.Command, args []string)
+	PersistentPreHook     func(cmd *cobra.Command, args []string)
+	PersistentPostHookErr func(cmd *cobra.Command, args []string) error
+	PersistentPreHookErr  func(cmd *cobra.Command, args []string) error
+	PostHook              func(cmd *cobra.Command, args []string)
+	PreHook               func(cmd *cobra.Command, args []string)
+	PostHookErr           func(cmd *cobra.Command, args []string) error
+	PreHookErr            func(cmd *cobra.Command, args []string) error
+	ShortDesc             string
+	SuggestFor            []string
+	ValidArgs             []string
+	ValidArgsFunc         func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+	Version               string
 }
 
 // Supported flags.
@@ -35,6 +49,17 @@ const (
 	BoolFlag
 )
 
+// FlagBindOptions exposes the parameters
+// used to bind a flag to a passed pointer.
+type FlagBindOptions struct {
+	Bound       bool
+	BindInt     *int
+	BindInt64   *int64
+	BindString  *string
+	BindBool    *bool
+	BindFloat64 *float64
+}
+
 // FlagConfig defines the configuration of a flag.
 type FlagConfig struct {
 	FlagType   int
@@ -44,6 +69,7 @@ type FlagConfig struct {
 	Default    interface{}
 	Required   bool
 	Persistent bool
+	Binding    FlagBindOptions
 }
 
 // Command wraps a base cobra command to add some
@@ -71,16 +97,31 @@ func (c *Command) GetSubCommands() []*Command {
 // Builder constructs a new command.
 func Builder(parent *Command, config Config, cols []string) *Command {
 	cc := &cobra.Command{
-		Use:       config.Namespace,
-		Short:     config.ShortDesc,
-		Long:      strings.TrimSpace(config.LongDesc),
-		Run:       config.Execute,
-		PreRun:    config.PreHook,
-		PostRun:   config.PostHook,
-		Hidden:    config.Hidden,
-		ValidArgs: config.ValidArgs,
-		Example:   config.Example,
-		Aliases:   config.Aliases,
+		Use:                config.Namespace,
+		Short:              config.ShortDesc,
+		Long:               strings.TrimSpace(config.LongDesc),
+		Run:                config.Execute,
+		RunE:               config.ExecuteErr,
+		PreRun:             config.PreHook,
+		PostRun:            config.PostHook,
+		Hidden:             config.Hidden,
+		ValidArgs:          config.ValidArgs,
+		ValidArgsFunction:  config.ValidArgsFunc,
+		Example:            config.Example,
+		Aliases:            config.Aliases,
+		Deprecated:         config.Deprecated,
+		DisableAutoGenTag:  config.DisableAutoGenTag,
+		DisableSuggestions: config.DisableSuggentions,
+		PersistentPreRun:   config.PersistentPreHook,
+		PersistentPostRun:  config.PersistentPostHook,
+		PersistentPreRunE:  config.PersistentPreHookErr,
+		PersistentPostRunE: config.PersistentPostHookErr,
+		Version:            config.Version,
+		SuggestFor:         config.SuggestFor,
+	}
+
+	if config.SuggestMinDistance > 1 {
+		cc.SuggestionsMinimumDistance = config.SuggestMinDistance
 	}
 
 	c := &Command{Command: cc, cols: cols}
@@ -134,24 +175,15 @@ func AddFlag(cmd *Command, config FlagConfig) {
 
 	switch config.FlagType {
 	case IntFlag:
-		val := config.Default.(int)
-		flagger.IntP(config.Name, config.Shorthand, val, config.Usage)
+		addIntFlag(flagger, &config)
 	case Int64Flag:
-		val := config.Default.(int64)
-		flagger.Int64P(config.Name, config.Shorthand, val, config.Usage)
+		addInt64Flag(flagger, &config)
 	case Float64Flag:
-		val := config.Default.(float64)
-		flagger.Float64P(config.Name, config.Shorthand, val, config.Usage)
+		addFloat64Flag(flagger, &config)
 	case BoolFlag:
-		val := config.Default.(bool)
-		flagger.BoolP(config.Name, config.Shorthand, val, config.Usage)
+		addBoolFlag(flagger, &config)
 	default:
-		if config.Default == nil {
-			config.Default = ""
-		}
-
-		val := config.Default.(string)
-		flagger.StringP(config.Name, config.Shorthand, val, config.Usage)
+		addStringFlag(flagger, &config)
 	}
 
 	if config.Required {
@@ -174,4 +206,53 @@ func FilterColumns(req string, def []string) []string {
 	}
 
 	return def
+}
+
+func addIntFlag(flagger *pflag.FlagSet, config *FlagConfig) {
+	val := config.Default.(int)
+	if config.Binding.Bound {
+		flagger.IntVarP(config.Binding.BindInt, config.Name, config.Shorthand, val, config.Usage)
+	} else {
+		flagger.IntP(config.Name, config.Shorthand, val, config.Usage)
+	}
+}
+
+func addInt64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
+	val := config.Default.(int64)
+	if config.Binding.Bound {
+		flagger.Int64VarP(config.Binding.BindInt64, config.Name, config.Shorthand, val, config.Usage)
+	} else {
+		flagger.Int64P(config.Name, config.Shorthand, val, config.Usage)
+	}
+}
+
+func addFloat64Flag(flagger *pflag.FlagSet, config *FlagConfig) {
+	val := config.Default.(float64)
+	if config.Binding.Bound {
+		flagger.Float64VarP(config.Binding.BindFloat64, config.Name, config.Shorthand, val, config.Usage)
+	} else {
+		flagger.Float64P(config.Name, config.Shorthand, val, config.Usage)
+	}
+}
+
+func addBoolFlag(flagger *pflag.FlagSet, config *FlagConfig) {
+	val := config.Default.(bool)
+	if config.Binding.Bound {
+		flagger.BoolVarP(config.Binding.BindBool, config.Name, config.Shorthand, val, config.Usage)
+	} else {
+		flagger.BoolP(config.Name, config.Shorthand, val, config.Usage)
+	}
+}
+
+func addStringFlag(flagger *pflag.FlagSet, config *FlagConfig) {
+	if config.Default == nil {
+		config.Default = ""
+	}
+
+	val := config.Default.(string)
+	if config.Binding.Bound {
+		flagger.StringVarP(config.Binding.BindString, config.Name, config.Shorthand, val, config.Usage)
+	} else {
+		flagger.StringP(config.Name, config.Shorthand, val, config.Usage)
+	}
 }

--- a/pkg/commander/command.go
+++ b/pkg/commander/command.go
@@ -9,8 +9,19 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// Cols contains the header for the column
+// based CLI displayer.
+type Cols []string
+
 // NoCols is a 0 column indicator.
-var NoCols = []string{}
+func NoCols() Cols {
+	return []string{}
+}
+
+// NewCols returns a cols type.
+func NewCols(vals ...string) Cols {
+	return vals
+}
 
 // Config contains a command configuration.
 type Config struct {
@@ -95,7 +106,7 @@ func (c *Command) GetSubCommands() []*Command {
 }
 
 // Builder constructs a new command.
-func Builder(parent *Command, config Config, cols []string) *Command {
+func Builder(parent *Command, config Config, cols Cols) *Command {
 	cc := &cobra.Command{
 		Use:                config.Namespace,
 		Short:              config.ShortDesc,

--- a/pkg/commander/command_test.go
+++ b/pkg/commander/command_test.go
@@ -141,6 +141,95 @@ func TestAddFlag_Persistent(t *testing.T) {
 	assert.IsType(t, false, flag)
 }
 
+func TestAddFlag_BindIntFlag(t *testing.T) {
+	parent := Builder(nil, Config{Namespace: "test"}, []string{})
+
+	var fint int
+	AddFlag(parent, FlagConfig{
+		FlagType: IntFlag,
+		Name:     "bind-int",
+		Default:  10,
+		Binding: FlagBindOptions{
+			Bound:   true,
+			BindInt: &fint,
+		},
+	})
+
+	flag, err := parent.Flags().GetInt("bind-int")
+
+	assert.Nil(t, err)
+	assert.Equal(t, 10, flag)
+	assert.Equal(t, fint, flag)
+	assert.IsType(t, 10, flag)
+}
+
+func TestAddFlag_BindStringFlag(t *testing.T) {
+	parent := Builder(nil, Config{Namespace: "test"}, []string{})
+
+	var x string
+	AddFlag(parent, FlagConfig{
+		Name:    "bind-string",
+		Default: "bound to var",
+		Binding: FlagBindOptions{
+			Bound:      true,
+			BindString: &x,
+		},
+	})
+
+	flag, err := parent.Flags().GetString("bind-string")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "bound to var", flag)
+	assert.Equal(t, x, flag)
+	assert.IsType(t, "x", flag)
+}
+
+func TestAddFlag_BindFloat64Flag(t *testing.T) {
+	parent := Builder(nil, Config{Namespace: "test"}, []string{})
+
+	var x float64
+	y := float64(10.1)
+	AddFlag(parent, FlagConfig{
+		FlagType: Float64Flag,
+		Name:     "bind-float",
+		Default:  y,
+		Binding: FlagBindOptions{
+			Bound:       true,
+			BindFloat64: &x,
+		},
+	})
+
+	flag, err := parent.Flags().GetFloat64("bind-float")
+
+	assert.Nil(t, err)
+	assert.Equal(t, y, flag)
+	assert.Equal(t, x, flag)
+	assert.IsType(t, y, flag)
+}
+
+func TestAddFlag_BindBoolFlag(t *testing.T) {
+	parent := Builder(nil, Config{Namespace: "test"}, []string{})
+
+	var x bool
+	y := false
+	AddFlag(parent, FlagConfig{
+		FlagType: BoolFlag,
+		Name:     "bind-bool",
+		Default:  y,
+		Binding: FlagBindOptions{
+			Bound:    true,
+			BindBool: &x,
+		},
+	})
+
+	flag, err := parent.Flags().GetBool("bind-bool")
+
+	assert.Nil(t, err)
+	assert.Equal(t, y, flag)
+	assert.Equal(t, x, flag)
+	assert.IsType(t, y, flag)
+}
+
 func TestFilterColumns(t *testing.T) {
 	cases := []struct {
 		name  string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows admiral to do flag binding with and without a pointer value.

Example:

```go
cmd := Builder(nil, Config{Namespace: "test"}, []string{})
        var x string
	AddFlag(cmd, FlagConfig{
		FlagType:  StringFlag,
		Name:      "test-flag",
		Shorthand: "t",
		Default:   "default",
                Binding: FlagBindOptions{
			Bound:      true,
			BindString: &x,
		},
	})
// on eval x will be set to default if no value is provided in the flag.
```
*for more examples check the tests added to the implementation*

## Motivation and context

Allow flag to variable binding.

## How has this been tested?

Unit tests added.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
